### PR TITLE
Fix duplicate loss message in Hangman game

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,16 +65,7 @@
 		</button>
 	</div>
 
-	<!-- Inline loss-only answer shown just below the submit button -->
-	<div class="inline-answer" ng-if="gameOver && !didWin">
-		<p class="result-text lose">
-			You lost! The correct word was:
-			<span class="answer">
-				<span ng-repeat="c in revealChars track by $index" class="reveal-char">{{c}}</span>
-			</span>
-		</p>
-		<button class="play-again" ng-click="playAgain()">Play again</button>
-	</div>
+	
 
 	<script>
 		// Initialize knob if available; keep UI working if not


### PR DESCRIPTION
This pull request addresses an issue where the loss message was being displayed twice when a player lost in the Hangman game. The redundant HTML block responsible for showing the loss message has been removed, ensuring that the message displays only once. This change improves the user experience by providing clearer feedback when the game is lost.

---

> This pull request was co-created with Cosine Genie

Original Task: [hangmanGameApp/lqm0ukojiyp3](https://cosine.sh/cosinedemo/hangmanGameApp/task/lqm0ukojiyp3)
Author: Eleftheria Batsou
